### PR TITLE
Removed persistentStore option from samples & Added a FAQ on Page Refresh

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,7 @@
+# Frequently Asked Questions
+
+1. [Why is the isAuthenticated flag reset to false on the client side when the page is refreshed (or reloaded)?](#Why-is-the-isAuthenticated-flag-reset-to-false-on-the-client-side-when-the-page-is-refreshed-(or-reloaded))
+
+## <a name="Why-is-the-isAuthenticated-flag-reset-to-false-on-the-client-side-when-the-page-is-refreshed-(or-reloaded)">Why is the isAuthenticated flag reset to false on the client side when the page is refreshed (or reloaded)?</a> ##
+
+This is by design. Because the tokens are not saved (persisted), refreshing the page will reset the authentication state, requiring the SDK to log in again. To maintain the authenticated state upon refresh, you should use the loginWithRedirect flow or the AuthenticationGuard component.

--- a/samples/basic/README.md
+++ b/samples/basic/README.md
@@ -2,8 +2,6 @@
 
 If you wish to run the example of this project, fill the `.env` file with configuration details.
 
-To add persistence options, edit `client.ts` inside src/client folder.
-
 ## Run the example
 
 * Run `npm install` to install the required modules.

--- a/samples/basic/src/client/client.ts
+++ b/samples/basic/src/client/client.ts
@@ -1,5 +1,4 @@
 import { TIDClient } from '@trimble-oss/trimble-id-react'
-import { PersistentStore } from '@trimble-oss/trimble-id-react'
 
 const tidClient = new TIDClient({
   config: {
@@ -8,9 +7,6 @@ const tidClient = new TIDClient({
     redirectUrl: import.meta.env.VITE_REDIRECT_URL,
     logoutRedirectUrl: import.meta.env.VITE_LOGOUT_REDIRECT_URL,
     scopes: [import.meta.env.VITE_SCOPES],
-  },
-  persistentOptions: {
-    persistentStore: "localStorage"
   }
 })
 

--- a/samples/react-router/src/client/client.ts
+++ b/samples/react-router/src/client/client.ts
@@ -8,9 +8,6 @@ const tidClient = new TIDClient({
     logoutRedirectUrl: import.meta.env.VITE_LOGOUT_REDIRECT_URL,
     scopes: [import.meta.env.VITE_SCOPES],
   },
-  persistentOptions:{
-    persistentStore: "sessionStorage"
-  }
 })
 
 export default tidClient


### PR DESCRIPTION
- Removed PersistentOptions in the react samples as PersistentOptions is no longer available in the SDK
- Added a FAQ (Why is the isAuthenticated flag reset to false on the client side when the page is refreshed (or reloaded)?)